### PR TITLE
fix: conflict between menu backdrop and backdrop-filter

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -31,147 +31,148 @@ const isActive = (path: string) => {
 </a>
 
 <header id="main-header" class="sticky top-0 z-40 w-full transition-colors duration-300">
-  <div class="app-layout header-scrolled-filter">
-    <div
-      id="top-nav-wrap"
-      class:list={[
-        "py-3 sm:py-5",
-        "relative w-full",
-        "flex items-center justify-between",
-        "transition-all duration-300",
-      ]}
-    >
-      <!-- Logo -->
-      <a
-        href="/"
-        class="group relative z-20 flex items-center gap-2 text-xl font-bold tracking-tight sm:text-2xl"
+  <div class="header-scrolled-filter w-full">
+    <div class="app-layout">
+      <div
+        id="top-nav-wrap"
+        class:list={[
+          "py-3 sm:py-5",
+          "relative w-full",
+          "flex items-center justify-between",
+          "transition-all duration-300",
+        ]}
       >
-        <!-- <span class="nav-logo-text">{SITE.title}</span> -->
-        <Logo class="w-37.5 dark:invert" />
-      </a>
-
-      <!-- Nav area -->
-      <nav id="nav-menu" class="flex items-center sm:gap-1">
-        <!-- Mobile hamburger (animated lines) -->
-        <button
-          id="menu-btn"
-          class="hamburger-btn sm:hidden"
-          aria-label="Open Menu"
-          aria-expanded="false"
-          aria-controls="mobile-menu"
+        <!-- Logo -->
+        <a
+          href="/"
+          class="group relative z-20 flex items-center gap-2 text-xl font-bold tracking-tight sm:text-2xl"
         >
-          <div class="hamburger-box">
-            <span class="hamburger-line hamburger-line--1"></span>
-            <span class="hamburger-line hamburger-line--2"></span>
-            <span class="hamburger-line hamburger-line--3"></span>
-          </div>
-        </button>
+          <!-- <span class="nav-logo-text">{SITE.title}</span> -->
+          <Logo class="w-37.5 dark:invert" />
+        </a>
 
-        <!-- Desktop links (always visible on sm+) -->
-        <ul class="hidden sm:flex sm:flex-row sm:items-center sm:gap-1">
-          <li>
-            <a
-              href="/posts"
-              class:list={["nav-link", { "nav-active": isActive("/posts") }]}
-              >Posts</a
-            >
-          </li>
-          <li>
-            <a
-              href="/tags"
-              class:list={["nav-link", { "nav-active": isActive("/tags") }]}
-              >Tags</a
-            >
-          </li>
-          <li>
-            <a
-              href="/about"
-              class:list={["nav-link", { "nav-active": isActive("/about") }]}
-              >About</a
-            >
-          </li>
-          <li class="flex items-center">
-            <a
-              href="/search"
-              class:list={["nav-link", { "nav-active": isActive("/search") }]}
-              title="Ir a búsqueda">Search</a
-            >
-          </li>
-          {
-            SITE.showArchives && (
-              <li>
-                <LinkButton
-                  href="/archives"
-                  class:list={[
-                    "nav-link",
-                    { "nav-active": isActive("/archives") },
-                  ]}
-                  title="Archives"
-                  aria-label="archives"
-                >
-                  <IconArchive class="hidden sm:inline-block" />
-                  <span class="sm:sr-only">Archives</span>
-                </LinkButton>
-              </li>
-            )
-          }
-          {
-            SITE.showGalleries && (
-              <li>
-                <LinkButton
-                  href="/galleries"
-                  class:list={[
-                    "nav-link",
-                    { "nav-active": isActive("/galleries") },
-                  ]}
-                  title="Galerías"
-                  aria-label="galleries"
-                >
-                  <IconGallery class="hidden sm:inline-block" />
-                  <span class="sm:sr-only">Galerías</span>
-                </LinkButton>
-              </li>
-            )
-          }
+        <!-- Nav area -->
+        <nav id="nav-menu" class="flex items-center sm:gap-1">
+          <!-- Mobile hamburger (animated lines) -->
+          <button
+            id="menu-btn"
+            class="hamburger-btn sm:hidden"
+            aria-label="Open Menu"
+            aria-expanded="false"
+            aria-controls="mobile-menu"
+          >
+            <div class="hamburger-box">
+              <span class="hamburger-line hamburger-line--1"></span>
+              <span class="hamburger-line hamburger-line--2"></span>
+              <span class="hamburger-line hamburger-line--3"></span>
+            </div>
+          </button>
 
-          <!-- Separator -->
-          <li class="flex items-center px-1" aria-hidden="true">
-            <div class="h-4 w-px bg-border/30"></div>
-          </li>
+          <!-- Desktop links (always visible on sm+) -->
+          <ul class="hidden sm:flex sm:flex-row sm:items-center sm:gap-1">
+            <li>
+              <a
+                href="/posts"
+                class:list={["nav-link", { "nav-active": isActive("/posts") }]}
+                >Posts</a
+              >
+            </li>
+            <li>
+              <a
+                href="/tags"
+                class:list={["nav-link", { "nav-active": isActive("/tags") }]}
+                >Tags</a
+              >
+            </li>
+            <li>
+              <a
+                href="/about"
+                class:list={["nav-link", { "nav-active": isActive("/about") }]}
+                >About</a
+              >
+            </li>
+            <li class="flex items-center">
+              <a
+                href="/search"
+                class:list={["nav-link", { "nav-active": isActive("/search") }]}
+                title="Ir a búsqueda">Search</a
+              >
+            </li>
+            {
+              SITE.showArchives && (
+                <li>
+                  <LinkButton
+                    href="/archives"
+                    class:list={[
+                      "nav-link",
+                      { "nav-active": isActive("/archives") },
+                    ]}
+                    title="Archives"
+                    aria-label="archives"
+                  >
+                    <IconArchive class="hidden sm:inline-block" />
+                    <span class="sm:sr-only">Archives</span>
+                  </LinkButton>
+                </li>
+              )
+            }
+            {
+              SITE.showGalleries && (
+                <li>
+                  <LinkButton
+                    href="/galleries"
+                    class:list={[
+                      "nav-link",
+                      { "nav-active": isActive("/galleries") },
+                    ]}
+                    title="Galerías"
+                    aria-label="galleries"
+                  >
+                    <IconGallery class="hidden sm:inline-block" />
+                    <span class="sm:sr-only">Galerías</span>
+                  </LinkButton>
+                </li>
+              )
+            }
 
-          <li class="flex items-center">
-            <button
-              data-search-trigger
-              class="nav-search-btn"
-              title="Buscar (⌘K)"
-              aria-label="Abrir búsqueda"
-              aria-keyshortcuts="Meta+K"
-            >
-              <IconSearch class="size-4.5" />
-              <kbd class="nav-kbd">⌘K</kbd>
-            </button>
-          </li>
-          {
-            SITE.lightAndDarkMode && (
-              <li class="flex items-center">
-                <button
-                  id="theme-btn"
-                  class="nav-icon-btn relative"
-                  title="Toggles light & dark"
-                  aria-label="auto"
-                  aria-live="polite"
-                >
-                  <IconMoon class="absolute top-1/2 left-1/2 -translate-1/2 scale-100 rotate-0 transition-all duration-300 dark:scale-0 dark:-rotate-90" />
-                  <IconSunHigh class="absolute top-1/2 left-1/2 -translate-1/2 scale-0 rotate-90 transition-all duration-300 dark:scale-100 dark:rotate-0" />
-                </button>
-              </li>
-            )
-          }
-        </ul>
-      </nav>
+            <!-- Separator -->
+            <li class="flex items-center px-1" aria-hidden="true">
+              <div class="h-4 w-px bg-border/30"></div>
+            </li>
+
+            <li class="flex items-center">
+              <button
+                data-search-trigger
+                class="nav-search-btn"
+                title="Buscar (⌘K)"
+                aria-label="Abrir búsqueda"
+                aria-keyshortcuts="Meta+K"
+              >
+                <IconSearch class="size-4.5" />
+                <kbd class="nav-kbd">⌘K</kbd>
+              </button>
+            </li>
+            {
+              SITE.lightAndDarkMode && (
+                <li class="flex items-center">
+                  <button
+                    id="theme-btn"
+                    class="nav-icon-btn relative"
+                    title="Toggles light & dark"
+                    aria-label="auto"
+                    aria-live="polite"
+                  >
+                    <IconMoon class="absolute top-1/2 left-1/2 -translate-1/2 scale-100 rotate-0 transition-all duration-300 dark:scale-0 dark:-rotate-90" />
+                    <IconSunHigh class="absolute top-1/2 left-1/2 -translate-1/2 scale-0 rotate-90 transition-all duration-300 dark:scale-100 dark:rotate-0" />
+                  </button>
+                </li>
+              )
+            }
+          </ul>
+        </nav>
+      </div>
     </div>
   </div>
-
   <!-- ===================== MOBILE DROPDOWN MENU (Floating Sheet) ===================== -->
   <div id="mobile-menu" class="mobile-menu sm:hidden" aria-hidden="true">
     <!-- Overlay/Backdrop -->


### PR DESCRIPTION
## Description

<!-- A clear and concise description of what the pull request does. Include any relevant motivation and background. -->

The menu backdrop is not compatible with backdrop-filter on `<header>`, because a filter on a parent element will affect `fixed` on its children.

Reference: [fixed_positioning](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/position#fixed_positioning)

To solve this issue, I moved the backdrop filter into the `header-scrolled-filter` class.

Additionally, I added a scroll listener. When users scroll pages, the menu will close.

## Types of changes

<!-- What types of changes does your code introduce to AstroPaper? Put an `x` in the boxes that apply -->

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. You can also fill these out after creating the PR. This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have read the [Contributing Guide](https://github.com/satnaing/astro-paper/blob/main/.github/CONTRIBUTING.md)
- [ ] I have added the necessary documentation (if appropriate)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->

## Related Issue

<!-- If this PR is related to an existing issue, link to it here. -->